### PR TITLE
define __FACEBOOK_HASKELL__

### DIFF
--- a/includes/ghc.mk
+++ b/includes/ghc.mk
@@ -77,6 +77,8 @@ $(includes_H_VERSION) : mk/project.mk | $$(dir $$@)/.
 	@echo '          && (pl1) == __GLASGOW_HASKELL_PATCHLEVEL1__ \'    >> $@
 	@echo '          && (pl2) <= __GLASGOW_HASKELL_PATCHLEVEL2__ )'    >> $@
 	@echo >> $@
+	@echo "#define __FACEBOOK_HASKELL__" >> $@
+	@echo >> $@
 	@echo "#endif /* __GHCVERSION_H__ */"          >> $@
 	@echo "Done."
 


### PR DESCRIPTION
Summary:
fbghc makes changes to apis exported by the ghc package, breaking consumers
like ghcide and possibly others like hlint 3, ormolu, etc.To work around this we
need to patch those consumers.
Conditional compilation via CPP is the standard workaround for this.

Test Plan:

tested with ghc 8.4.4 only by building and running retrie